### PR TITLE
Fix hang on master=local

### DIFF
--- a/spark-greenplum-connector/src/main/scala/org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil.scala
+++ b/spark-greenplum-connector/src/main/scala/org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil.scala
@@ -471,11 +471,16 @@ object SparkSchemaUtil {
 
   def guessMaxParallelTasks(): Int = {
     val sparkContext = SparkContext.getOrCreate
+    if (sparkContext.master.contains("local")) {
+      return sparkContext.defaultParallelism
+    }
+
     var guess: Int = -1
     while ((guess <= 0) && !Thread.currentThread().isInterrupted) {
       guess = sparkContext.getExecutorMemoryStatus.keys.size - 1
-      if (sparkContext.deployMode == "cluster")
+      if (sparkContext.deployMode == "cluster") {
         guess -= 1
+      }
     }
     guess
   }


### PR DESCRIPTION
Using this connector with session created with `.master("local[1]")` hang because `sparkContext.getExecutorMemoryStatus()` always return 1, so `guess` is always 0, and while loop never ends. This was already reported in #14.

Added a check that if session created with `.master("local")` or `.master("local[N]")`, the value of `sparkContext.defaultParallelism` is returned:
* https://github.com/apache/spark/blob/v3.5.4/core/src/main/scala/org/apache/spark/SparkContext.scala#L2703
* https://github.com/apache/spark/blob/v3.5.4/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L1009
* https://github.com/apache/spark/blob/v3.5.4/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala#L684-L686