### PR TITLE
Avoid parsing DateTimeFormat on every row

### DIFF
--- a/spark-greenplum-connector/src/main/scala/com/itsumma/gpconnector/reader/GreenplumInputPartitionReader.scala
+++ b/spark-greenplum-connector/src/main/scala/com/itsumma/gpconnector/reader/GreenplumInputPartitionReader.scala
@@ -34,6 +34,7 @@ class GreenplumInputPartitionReader(optionsFactory: GPOptionsFactory,
   private val stageId: Int = TaskContext.get.stageId()
   private val exId: String = SparkEnv.get.executorId
   private val progressTracker: ProgressTracker = new ProgressTracker()
+  private val sparkSchemaUtil: SparkSchemaUtil = SparkSchemaUtil(optionsFactory.dbTimezone)
 
   private var schemaOrPlaceholder = schema
   if (schemaOrPlaceholder.isEmpty) {
@@ -95,7 +96,7 @@ class GreenplumInputPartitionReader(optionsFactory: GPOptionsFactory,
               if (schema.nonEmpty) rowString.split(fieldDelimiter) else "".split(fieldDelimiter)
             }
             val row = progressTracker.trackProgress("parseFields") {
-              SparkSchemaUtil(optionsFactory.dbTimezone).textToInternalRow(schemaOrPlaceholder, fields)
+              sparkSchemaUtil.textToInternalRow(schemaOrPlaceholder, fields)
             }
             val startEnq = System.nanoTime()
             convNs += System.nanoTime() - startConv

--- a/spark-greenplum-connector/src/main/scala/com/itsumma/gpconnector/reader/GreenplumScanBuilder.scala
+++ b/spark-greenplum-connector/src/main/scala/com/itsumma/gpconnector/reader/GreenplumScanBuilder.scala
@@ -17,6 +17,7 @@ class GreenplumScanBuilder(optionsFactory: GPOptionsFactory, rowSet: GreenplumRo
   private var pushedDownFilters: Array[Filter] = new Array[Filter](0)
   logDebug(s"""options=\n${optionsFactory.dumpParams()}""")
   private var greenplumScan: GreenplumScan = null
+  private val sparkSchemaUtil: SparkSchemaUtil = SparkSchemaUtil(optionsFactory.dbTimezone)
 
   override def build(): Scan = this.synchronized {
     if (greenplumScan == null)
@@ -25,7 +26,7 @@ class GreenplumScanBuilder(optionsFactory: GPOptionsFactory, rowSet: GreenplumRo
   }
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    val tuple3 = SparkSchemaUtil(optionsFactory.dbTimezone).pushFilters(filters)
+    val tuple3 = sparkSchemaUtil.pushFilters(filters)
     whereClause = tuple3._1
     pushedDownFilters = tuple3._3
     tuple3._2

--- a/spark-greenplum-connector/src/main/scala/com/itsumma/gpconnector/writer/GreenplumDataWriter.scala
+++ b/spark-greenplum-connector/src/main/scala/com/itsumma/gpconnector/writer/GreenplumDataWriter.scala
@@ -43,6 +43,7 @@ class GreenplumDataWriter(writeUUID: String, schema: StructType, optionsFactory:
   private val instanceId: String = s"$partitionId:$taskId:$epochId"
   private var rmiSlave: RMISlave = null
   private val progressTracker: ProgressTracker = new ProgressTracker()
+  private val sparkSchemaUtil: SparkSchemaUtil = SparkSchemaUtil(optionsFactory.dbTimezone)
 
   //init()
 
@@ -74,7 +75,7 @@ class GreenplumDataWriter(writeUUID: String, schema: StructType, optionsFactory:
         init()
     }
     val txt = progressTracker.trackProgress("row2text") {
-      SparkSchemaUtil(optionsFactory.dbTimezone).internalRowToText(schema, t, fieldDelimiter)
+      sparkSchemaUtil.internalRowToText(schema, t, fieldDelimiter)
     }
     //logDebug(s"write numFields=${t.numFields}, row(${rowCount.get()})='${txt}'")
     val writeStart: Long = System.currentTimeMillis()


### PR DESCRIPTION
I've discovered that handling every row during write/read process leads calls for `DateTimeFormatter.ofPattern(...)`. This takes quite time.

I've updated the code to parse pattern only once, then DataFrameWriter/DataFrameReader is created.

Before this change writing 11Gb of orc.snappy files to GP (309M rows, 207 columns) took 40 minutes:
[profile.small_orc2gp_itsumma.pb.gz](https://github.com/user-attachments/files/18394289/profile.small_orc2gp_itsumma.pb.gz)
[profile.small_orc2gp_itsumma.flamegraph.pb.tar.gz](https://github.com/user-attachments/files/18394299/profile.small_orc2gp_itsumma.flamegraph.pb.tar.gz)

<details>
<summary>Top method calls</summary>

```
Type: cpu
Time: Jan 10, 2025 at 1:43pm (MSK)
Duration: 2477s, Total samples = 2687.02s (108.48%)
Showing nodes accounting for 1983.19s, 73.81% of 2687.02s total
Dropped 9875 nodes (cum <= 13.44s)
      flat  flat%   sum%        cum   cum%
   203.81s  7.58%  7.58%    447.09s 16.64%  java/time/format/DateTimeFormatterBuilder.parsePattern
   115.86s  4.31% 11.90%    115.86s  4.31%  .jbyte_disjoint_arraycopy
    71.23s  2.65% 14.55%    928.68s 34.56%  org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil.$anonfun$internalRowToText$1
    63.23s  2.35% 16.90%     63.68s  2.37%  java/lang/Long.getChars
    62.13s  2.31% 19.21%     63.35s  2.36%  scala/runtime/BoxesRunTime.boxToInteger
    61.77s  2.30% 21.51%     61.77s  2.30%  .[vdso]
    53.69s  2.00% 23.51%     53.69s  2.00%  .itable stub
    49.55s  1.84% 25.35%    310.56s 11.56%  org/apache/spark/sql/catalyst/expressions/GeneratedClass$GeneratedIteratorForCodegenStage1.processNext
    47.72s  1.78% 27.13%    133.14s  4.95%  java/time/format/DateTimeFormatterBuilder$NumberPrinterParser.format
    43.61s  1.62% 28.75%     43.61s  1.62%  .jbyte_arraycopy
    42.90s  1.60% 30.35%     73.97s  2.75%  jdk/internal/math/FloatToDecimal.<init>
    40.50s  1.51% 31.86%     90.93s  3.38%  java/time/format/DateTimeFormatterBuilder$CompositePrinterParser.<init>
    40.47s  1.51% 33.36%     51.27s  1.91%  java/lang/AbstractStringBuilder.ensureCapacityInternal
    37.27s  1.39% 34.75%     37.27s  1.39%  libpthread-2.28.so..annobin___pthread_cond_timedwait.start
    36.92s  1.37% 36.12%    130.12s  4.84%  java/time/format/DateTimeFormatterBuilder.appendValue
    34.02s  1.27% 37.39%     46.61s  1.73%  .checkcast_arraycopy_uninit
    33.39s  1.24% 38.63%     33.39s  1.24%  .jlong_disjoint_arraycopy
    33.07s  1.23% 39.86%    960.89s 35.76%  org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil$$Lambda_.apply
    33.01s  1.23% 41.09%     47.03s  1.75%  java/util/ArrayList.grow
    31.35s  1.17% 42.26%     31.44s  1.17%  libpthread-2.28.so.__write
    31.12s  1.16% 43.42%     78.43s  2.92%  java/util/ArrayList.add
    30.63s  1.14% 44.56%    166.38s  6.19%  java/time/format/DateTimeFormatterBuilder.parseField
    30.60s  1.14% 45.70%    217.56s  8.10%  java/lang/AbstractStringBuilder.append
    30.26s  1.13% 46.82%     34.58s  1.29%  java/time/OffsetDateTime.getLong
    28.27s  1.05% 47.87%     28.55s  1.06%  sun/misc/Unsafe.getLong
    27.16s  1.01% 48.88%     82.68s  3.08%  jdk/internal/math/FloatToDecimal.toDecimal
    26.31s  0.98% 49.86%    998.08s 37.14%  scala/collection/IndexedSeqOptimized.foreach
    26.20s  0.98% 50.84%     26.84s     1%  java/lang/Integer.getChars
    23.29s  0.87% 51.71%    121.19s  4.51%  org/apache/orc/impl/TreeReaderFactory$FloatTreeReader.nextVector
    23.07s  0.86% 52.56%     23.07s  0.86%  libjvm.so..annobin__ZN12G1BarrierSet10invalidateE9MemRegion.start
    22.60s  0.84% 53.41%     22.62s  0.84%  scala/collection/mutable/StringBuilder.underlying
    22.36s  0.83% 54.24%     95.18s  3.54%  java/lang/Long.toString
    22.25s  0.83% 55.07%     22.25s  0.83%  java/lang/Long.stringSize
    21.83s  0.81% 55.88%    101.25s  3.77%  java/time/format/DateTimeFormatterBuilder.appendInternal
    21.55s   0.8% 56.68%     25.55s  0.95%  scala/runtime/BoxesRunTime.boxToBoolean
    21.32s  0.79% 57.47%     21.32s  0.79%  scala/collection/mutable/ArrayBuilder$ofRef.elems_$eq
    20.36s  0.76% 58.23%    113.54s  4.23%  java/lang/String.getBytes
    18.88s   0.7% 58.93%     23.67s  0.88%  java/time/format/DateTimeFormatterBuilder$CharLiteralPrinterParser.format
    18.13s  0.67% 59.61%     19.42s  0.72%  java/util/Arrays.copyOf
    17.91s  0.67% 60.27%     18.01s  0.67%  libjvm.so.void OopOopIterateDispatch<G1CMOopClosure>::Table::oop_oop_iterate<InstanceKlass, narrowOop>
    17.08s  0.64% 60.91%     28.88s  1.07%  io/airlift/compress/snappy/SnappyRawDecompressor.uncompressAll
    17.06s  0.63% 61.55%     64.80s  2.41%  java/nio/HeapByteBuffer.get
    16.86s  0.63% 62.17%     20.05s  0.75%  org/apache/spark/sql/execution/datasources/orc/OrcColumnVector.isNullAt
    16.19s   0.6% 62.78%     16.20s   0.6%  java/lang/String.coder
    15.35s  0.57% 63.35%     50.67s  1.89%  jdk/internal/math/FloatToDecimal.toChars
    14.52s  0.54% 63.89%     20.58s  0.77%  scala/runtime/BoxesRunTime.boxToLong
    14.21s  0.53% 64.42%    668.03s 24.86%  org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil.<init>
    13.87s  0.52% 64.93%     29.94s  1.11%  java/util/concurrent/ConcurrentHashMap.get
    13.60s  0.51% 65.44%    204.23s  7.60%  java/time/format/DateTimeFormatterBuilder$CompositePrinterParser.format
    11.59s  0.43% 65.87%     21.89s  0.81%  java/lang/String.<init>
     9.94s  0.37% 66.24%     25.01s  0.93%  jdk/internal/math/FloatToDecimal.toChars1
     9.14s  0.34% 66.58%     53.96s  2.01%  org/apache/orc/impl/RunLengthIntegerReaderV2.nextVector
     9.07s  0.34% 66.92%     89.71s  3.34%  org/apache/orc/impl/SerializationUtils.readFloat
     8.86s  0.33% 67.25%     60.43s  2.25%  org/apache/commons/lang3/time/FormatCache.getInstance
     8.10s   0.3% 67.55%     29.28s  1.09%  java/util/Arrays.hashCode
     7.69s  0.29% 67.83%        23s  0.86%  java/lang/String.length
     7.65s  0.28% 68.12%     33.87s  1.26%  org/apache/spark/unsafe/bitset/BitSetMethods.isSet
     7.53s  0.28% 68.40%    103.84s  3.86%  scala/collection/IndexedSeqOptimized.zipWithIndex
     7.43s  0.28% 68.68%     14.92s  0.56%  java/time/format/DateTimePrintContext.<init>
     7.25s  0.27% 68.95%     60.22s  2.24%  libc-2.28.so.clock_gettime@@GLIBC_2.17
     6.89s  0.26% 69.20%     99.61s  3.71%  java/time/format/DateTimeFormatterBuilder.toFormatter
     6.85s  0.25% 69.46%     39.07s  1.45%  java/lang/Integer.toString
     5.89s  0.22% 69.68%   2243.14s 83.48%  org/apache/spark/sql/execution/datasources/v2/WritingSparkTask.$anonfun$run$1
     5.77s  0.21% 69.89%     15.98s  0.59%  libjvm.so.G1RebuildRSAndScrubTask::G1RebuildRSAndScrubRegionClosure::do_heap_region
     5.74s  0.21% 70.10%     14.84s  0.55%  jdk/internal/math/FloatToDecimal.charsToString
     5.61s  0.21% 70.31%     13.93s  0.52%  scala/reflect/ClassTag$.apply
     5.38s   0.2% 70.51%     15.06s  0.56%  java/time/format/DateTimeFormatterBuilder.appendFraction
     5.31s   0.2% 70.71%     24.63s  0.92%  org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.write
     5.04s  0.19% 70.90%     44.82s  1.67%  org/apache/orc/impl/RunLengthIntegerReaderV2.next
     4.37s  0.16% 71.06%   1924.23s 71.61%  com/itsumma/gpconnector/writer/GreenplumDataWriter.write
     4.19s  0.16% 71.22%     38.81s  1.44%  org/apache/orc/impl/InStream$CompressedStream.ensureUncompressed
     3.82s  0.14% 71.36%     29.61s  1.10%  org/apache/orc/impl/SerializationUtils.readLongBE
     3.59s  0.13% 71.49%     25.74s  0.96%  com/itsumma/gpconnector/rmi/BufferExchange.put
     3.57s  0.13% 71.63%     84.98s  3.16%  com/itsumma/gpconnector/rmi/RMISlave.write
     3.55s  0.13% 71.76%   1130.64s 42.08%  org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil.internalRowToText
     3.30s  0.12% 71.88%     19.84s  0.74%  java/time/format/DateTimeFormatterBuilder.appendLiteral
     3.28s  0.12% 72.00%   1954.75s 72.75%  com/itsumma/gpconnector/utils/ProgressTracker.trackProgress
     3.22s  0.12% 72.12%     46.46s  1.73%  java/time/ZoneId.of
     3.10s  0.12% 72.24%    113.87s  4.24%  java/lang/AbstractStringBuilder.putStringAt
     2.97s  0.11% 72.35%     31.61s  1.18%  libjvm.so.void G1CMTask::process_grey_task_entry<true>
     2.78s   0.1% 72.45%     39.23s  1.46%  com/itsumma/gpconnector/rmi/RMISlave.putLocal
     2.63s 0.098% 72.55%    105.97s  3.94%  org/apache/orc/impl/InStream$CompressedStream.read
     2.04s 0.076% 72.63%     53.70s  2.00%  java/time/format/DateTimePrintContext.getValue
     2.03s 0.076% 72.70%     23.41s  0.87%  libjvm.so.HeapRegionManager::par_iterate
     2.02s 0.075% 72.78%     25.59s  0.95%  java/time/ZonedDateTime.ofInstant
     1.92s 0.071% 72.85%     18.77s   0.7%  libjvm.so.Unsafe_Park
     1.70s 0.063% 72.91%     36.58s  1.36%  libjvm.so.G1CMBitMapClosure::do_addr
     1.56s 0.058% 72.97%     17.20s  0.64%  libjvm.so.G1CMTask::drain_local_queue
     1.29s 0.048% 73.02%     32.83s  1.22%  org/apache/orc/impl/RunLengthIntegerReaderV2.readDirectValues
     1.28s 0.048% 73.07%     59.92s  2.23%  jdk/internal/misc/Unsafe.park
     1.17s 0.044% 73.11%     16.96s  0.63%  java/time/LocalDateTime.ofEpochSecond
     1.07s  0.04% 73.15%     98.39s  3.66%  jdk/internal/math/FloatToDecimal.toDecimalString
     1.06s 0.039% 73.19%     39.78s  1.48%  org/apache/orc/impl/RunLengthIntegerReaderV2.readValues
        1s 0.037% 73.23%     32.41s  1.21%  org/apache/orc/impl/SerializationUtils.unrolledUnPackBytes
     0.88s 0.033% 73.26%     81.96s  3.05%  com/itsumma/gpconnector/rmi/RMISlave.tryGet
     0.82s 0.031% 73.29%    218.43s  8.13%  java/lang/StringBuilder.append
     0.79s 0.029% 73.32%     42.72s  1.59%  libjvm.so.G1CMTask::do_marking_step
     0.77s 0.029% 73.35%     26.20s  0.98%  java/time/Instant.atZone
     0.73s 0.027% 73.37%     59.46s  2.21%  org/apache/commons/lang3/time/FastDateFormat.getInstance
     0.65s 0.024% 73.40%     23.42s  0.87%  java/time/ZonedDateTime.create
     0.65s 0.024% 73.42%     13.99s  0.52%  org/apache/spark/internal/Logging.logTrace
     0.62s 0.023% 73.45%    230.92s  8.59%  java/time/format/DateTimeFormatter.format
     0.59s 0.022% 73.47%     14.42s  0.54%  libjvm.so.MemAllocator::allocate
     0.57s 0.021% 73.49%    447.54s 16.66%  java/time/format/DateTimeFormatterBuilder.appendPattern
     0.55s  0.02% 73.51%   1800.71s 67.02%  com/itsumma/gpconnector/writer/GreenplumDataWriter$$Lambda_.apply
     0.55s  0.02% 73.53%    219.82s  8.18%  java/time/format/DateTimeFormatter.formatTo
     0.54s  0.02% 73.55%     33.77s  1.26%  org/apache/orc/impl/SerializationUtils.readInts
     0.53s  0.02% 73.57%     69.94s  2.60%  java/util/concurrent/locks/AbstractQueuedSynchronizer$ConditionObject.awaitNanos
     0.51s 0.019% 73.59%   1800.16s 66.99%  com/itsumma/gpconnector/writer/GreenplumDataWriter.$anonfun$write$1
     0.47s 0.017% 73.61%    134.21s  4.99%  libjvm.so..annobin__ZN12WorkerThread3runEv.start
     0.44s 0.016% 73.62%     31.98s  1.19%  sun/nio/ch/SocketDispatcher.write0
     0.41s 0.015% 73.64%    311.04s 11.58%  org/apache/spark/sql/execution/BufferedRowIterator.hasNext
     0.35s 0.013% 73.65%    311.39s 11.59%  org/apache/spark/sql/execution/WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext
     0.34s 0.013% 73.66%     78.53s  2.92%  com/itsumma/gpconnector/rmi/BufferExchange.get
     0.34s 0.013% 73.68%     29.95s  1.11%  org/apache/commons/lang3/time/FormatCache$ArrayKey.<init>
     0.33s 0.012% 73.69%     29.61s  1.10%  org/apache/commons/lang3/time/FormatCache$ArrayKey.computeHashCode
     0.27s  0.01% 73.70%     82.72s  3.08%  com/itsumma/gpconnector/rmi/RMISlave.read
     0.24s 0.0089% 73.71%     22.21s  0.83%  scala/collection/MapLike.getOrElse
     0.23s 0.0086% 73.72%    104.06s  3.87%  scala/collection/IndexedSeqOptimized.zipWithIndex$
     0.23s 0.0086% 73.72%     36.83s  1.37%  sun/net/httpserver/ChunkedOutputStream.writeChunk
     0.20s 0.0074% 73.73%     45.85s  1.71%  org/apache/orc/impl/TreeReaderFactory$LongTreeReader.nextVector
     0.14s 0.0052% 73.74%     29.03s  1.08%  io/airlift/compress/snappy/SnappyRawDecompressor.decompress
     0.13s 0.0048% 73.74%        34s  1.27%  org/apache/spark/sql/catalyst/expressions/UnsafeRow.isNullAt
     0.13s 0.0048% 73.75%     36.42s  1.36%  sun/net/httpserver/Request$WriteStream.write
     0.12s 0.0045% 73.75%     32.13s  1.20%  java/time/ZoneRegion.ofId
     0.12s 0.0045% 73.76%    215.31s  8.01%  scala/collection/mutable/StringBuilder.append
     0.12s 0.0045% 73.76%     31.69s  1.18%  sun/nio/ch/IOUtil.writeFromNativeBuffer
     0.10s 0.0037% 73.76%     39.12s  1.46%  libjvm.so.G1EvacuateRegionsBaseTask::work
     0.10s 0.0037% 73.77%    189.81s  7.06%  org/apache/spark/sql/catalyst/expressions/GeneratedClass$GeneratedIteratorForCodegenStage1.columnartorow_nextBatch_0$
     0.08s 0.003% 73.77%     80.64s  3.00%  org/apache/orc/impl/SerializationUtils.readFully
     0.07s 0.0026% 73.77%   2372.69s 88.30%  java/util/concurrent/ThreadPoolExecutor.runWorker
     0.07s 0.0026% 73.78%     22.28s  0.83%  scala/collection/MapLike.getOrElse$
     0.07s 0.0026% 73.78%     33.60s  1.25%  sun/nio/ch/IOUtil.write
     0.06s 0.0022% 73.78%   2385.84s 88.79%  java/lang/Thread.run
     0.06s 0.0022% 73.78%     19.93s  0.74%  libjvm.so.G1ParEvacuateFollowersClosure::do_void
     0.05s 0.0019% 73.78%    122.71s  4.57%  com/itsumma/gpconnector/gpfdist/WebServer$$anon$1$$Lambda_.apply$mcV$sp
     0.05s 0.0019% 73.79%    178.64s  6.65%  org/apache/orc/impl/reader/tree/StructBatchReader.nextBatchForLevel
     0.05s 0.0019% 73.79%     40.48s  1.51%  sun/net/httpserver/ChunkedOutputStream.write
     0.04s 0.0015% 73.79%    125.06s  4.65%  com/itsumma/gpconnector/gpfdist/WebServer$$anon$1.handle
     0.04s 0.0015% 73.79%    182.33s  6.79%  org/apache/orc/impl/RecordReaderImpl.nextBatch
     0.04s 0.0015% 73.79%    178.68s  6.65%  org/apache/orc/impl/reader/tree/StructBatchReader.nextBatch
     0.03s 0.0011% 73.79%     14.61s  0.54%  libjvm.so.G1RootProcessor::evacuate_roots
     0.03s 0.0011% 73.79%    125.97s  4.69%  sun/net/httpserver/ServerImpl$Exchange.run
     0.02s 0.00074% 73.80%     20.26s  0.75%  java/lang/Short.toString
     0.02s 0.00074% 73.80%    548.80s 20.42%  java/time/format/DateTimeFormatter.ofPattern
     0.02s 0.00074% 73.80%     29.39s  1.09%  org/apache/orc/impl/InStream$CompressedStream.readHeader
     0.02s 0.00074% 73.80%   2243.73s 83.50%  org/apache/spark/executor/Executor$TaskRunner.run
     0.02s 0.00074% 73.80%    123.59s  4.60%  scala/runtime/java8/JFunction0$mcV$sp.apply
     0.02s 0.00074% 73.80%     35.33s  1.31%  sun/nio/ch/SocketChannelImpl.write
     0.01s 0.00037% 73.80%     40.51s  1.51%  com/itsumma/gpconnector/gpfdist/WebServer$$anon$1.$anonfun$handle$4
     0.01s 0.00037% 73.80%    125.07s  4.65%  com/sun/net/httpserver/Filter$Chain.doFilter
     0.01s 0.00037% 73.80%   2372.70s 88.30%  java/util/concurrent/ThreadPoolExecutor$Worker.run
     0.01s 0.00037% 73.80%     59.53s  2.22%  java/util/concurrent/locks/LockSupport.parkNanos
     0.01s 0.00037% 73.80%    172.45s  6.42%  jdk/internal/math/FloatToDecimal.toString
     0.01s 0.00037% 73.80%     18.84s   0.7%  libjvm.so..annobin__ZN21G1EvacuateRegionsTask21evacuate_live_objectsEP20G1ParScanThreadStatej.start
     0.01s 0.00037% 73.80%     18.73s   0.7%  libjvm.so..annobin__ZN23G1RebuildRSAndScrubTask4workEj.start
     0.01s 0.00037% 73.80%     14.73s  0.55%  libjvm.so.Compile::Optimize
     0.01s 0.00037% 73.80%     49.03s  1.82%  libjvm.so.CompileBroker::compiler_thread_loop
     0.01s 0.00037% 73.80%     14.66s  0.55%  libjvm.so.PhaseChaitin::Register_Allocate
     0.01s 0.00037% 73.80%    194.39s  7.23%  libpthread-2.28.so.start_thread
     0.01s 0.00037% 73.80%    178.35s  6.64%  org/apache/orc/impl/reader/tree/StructBatchReader.readBatchColumn
     0.01s 0.00037% 73.80%     13.99s  0.52%  org/apache/spark/internal/Logging.logTrace$
     0.01s 0.00037% 73.80%   2243.45s 83.49%  org/apache/spark/scheduler/Task.run
     0.01s 0.00037% 73.80%    187.61s  6.98%  org/apache/spark/sql/execution/datasources/FileScanRDD$$anon$1.hasNext
     0.01s 0.00037% 73.81%    182.35s  6.79%  org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.nextBatch
     0.01s 0.00037% 73.81%   2243.17s 83.48%  org/apache/spark/sql/execution/datasources/v2/WritingSparkTask.run
     0.01s 0.00037% 73.81%     22.29s  0.83%  scala/collection/AbstractMap.getOrElse
     0.01s 0.00037% 73.81%     31.99s  1.19%  sun/nio/ch/SocketDispatcher.write
         0     0% 73.81%     63.34s  2.36%  .not_walkable_Java
         0     0% 73.81%     63.73s  2.37%  .unknown
         0     0% 73.81%     19.94s  0.74%  .unknown_Java
         0     0% 73.81%     81.85s  3.05%  com/itsumma/gpconnector/gpfdist/WebServer$$anon$1.$anonfun$handle$5
         0     0% 73.81%     29.03s  1.08%  io/airlift/compress/snappy/SnappyDecompressor.decompress
         0     0% 73.81%    172.45s  6.42%  java/lang/Float.toString
         0     0% 73.81%   2385.78s 88.79%  java/lang/Thread.runWith
         0     0% 73.81%     21.84s  0.81%  java/time/zone/ZoneRulesProvider.getRules
         0     0% 73.81%     18.47s  0.69%  libjvm.so..annobin__ZN21G1EvacuateRegionsTask10scan_rootsEP20G1ParScanThreadStatej.start
         0     0% 73.81%     41.25s  1.54%  libjvm.so.C2Compiler::compile_method
         0     0% 73.81%     22.54s  0.84%  libjvm.so.Compile::Code_Gen
         0     0% 73.81%     41.24s  1.53%  libjvm.so.Compile::Compile
         0     0% 73.81%     48.74s  1.81%  libjvm.so.CompileBroker::invoke_compiler_on_method
         0     0% 73.81%     44.54s  1.66%  libjvm.so.G1CMConcurrentMarkingTask::work
         0     0% 73.81%     14.31s  0.53%  libjvm.so.G1RootProcessor::process_java_roots
         0     0% 73.81%     49.39s  1.84%  libjvm.so.JavaThread::thread_main_inner
         0     0% 73.81%    194.32s  7.23%  libjvm.so.Thread::call_run
         0     0% 73.81%    194.36s  7.23%  libjvm.so.thread_native_entry
         0     0% 73.81%     29.04s  1.08%  org/apache/orc/impl/AircompressorCodec.decompress
         0     0% 73.81%     15.66s  0.58%  org/apache/orc/impl/SerializationUtils.unrolledUnPack32
         0     0% 73.81%     29.05s  1.08%  org/apache/orc/impl/SnappyCodec.decompress
         0     0% 73.81%   2243.37s 83.49%  org/apache/spark/TaskContext.runTaskWithListeners
         0     0% 73.81%   2243.45s 83.49%  org/apache/spark/executor/Executor$TaskRunner$$Lambda_.apply
         0     0% 73.81%   2243.45s 83.49%  org/apache/spark/executor/Executor$TaskRunner.$anonfun$run$4
         0     0% 73.81%   2243.36s 83.49%  org/apache/spark/scheduler/ResultTask.runTask
         0     0% 73.81%    187.65s  6.98%  org/apache/spark/sql/execution/FileSourceScanExec$$anon$1.hasNext
         0     0% 73.81%    182.35s  6.79%  org/apache/spark/sql/execution/datasources/RecordReaderIterator.hasNext
         0     0% 73.81%    182.35s  6.79%  org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.nextKeyValue
         0     0% 73.81%   2243.17s 83.48%  org/apache/spark/sql/execution/datasources/v2/DataWritingSparkTask$.run
         0     0% 73.81%   1924.10s 71.61%  org/apache/spark/sql/execution/datasources/v2/DataWritingSparkTask$.write
         0     0% 73.81%   2243.17s 83.48%  org/apache/spark/sql/execution/datasources/v2/V2TableWriteExec$$Lambda_.apply
         0     0% 73.81%   2243.17s 83.48%  org/apache/spark/sql/execution/datasources/v2/V2TableWriteExec.$anonfun$writeWithV2$2
         0     0% 73.81%   2243.14s 83.48%  org/apache/spark/sql/execution/datasources/v2/WritingSparkTask$$Lambda_.apply
         0     0% 73.81%   2243.17s 83.48%  org/apache/spark/sql/execution/datasources/v2/WritingSparkTask.run$
         0     0% 73.81%     27.85s  1.04%  org/apache/spark/unsafe/Platform.getLong
         0     0% 73.81%   2243.50s 83.49%  org/apache/spark/util/SparkErrorUtils.tryWithSafeFinally
         0     0% 73.81%   2243.50s 83.49%  org/apache/spark/util/SparkErrorUtils.tryWithSafeFinally$
         0     0% 73.81%   2243.50s 83.49%  org/apache/spark/util/Utils$.tryWithSafeFinally
         0     0% 73.81%   2243.14s 83.48%  org/apache/spark/util/Utils$.tryWithSafeFinallyAndFailureCallbacks
         0     0% 73.81%     25.52s  0.95%  scala/Predef$.boolean2Boolean
         0     0% 73.81%    998.08s 37.14%  scala/collection/IndexedSeqOptimized.foreach$
         0     0% 73.81%     25.43s  0.95%  scala/collection/mutable/ArrayBuilder$ofRef.resize
         0     0% 73.81%     22.75s  0.85%  scala/collection/mutable/ArrayBuilder$ofRef.sizeHint
         0     0% 73.81%    997.13s 37.11%  scala/collection/mutable/ArrayOps$ofRef.foreach
         0     0% 73.81%    104.06s  3.87%  scala/collection/mutable/ArrayOps$ofRef.zipWithIndex
         0     0% 73.81%     20.74s  0.77%  scala/runtime/java8/JFunction0$mcJ$sp.apply
         0     0% 73.81%    125.06s  4.65%  sun/net/httpserver/AuthFilter.doFilter
         0     0% 73.81%     40.49s  1.51%  sun/net/httpserver/PlaceholderOutputStream.write
         0     0% 73.81%    125.06s  4.65%  sun/net/httpserver/ServerImpl$Exchange$LinkHandler.handle
```
</details>

After this change the same amount of data was written in 28 minutes, +30% of performance:
[profile.small_orc2gp_itsumma_patched.pb.gz](https://github.com/user-attachments/files/18394339/profile.small_orc2gp_itsumma_patched.pb.gz)
[profile.small_orc2gp_itsumma_patched.pb.flamegraph.tar.gz](https://github.com/user-attachments/files/18394363/profile.small_orc2gp_itsumma_patched.pb.flamegraph.tar.gz)
<details>
<summary>Top method calls</summary>

```
Type: cpu
Time: Jan 13, 2025 at 11:22am (MSK)
Duration: 3179.42s, Total samples = 2142.99s (67.40%)
Showing nodes accounting for 1505.04s, 70.23% of 2142.99s total
Dropped 12496 nodes (cum <= 10.71s)
      flat  flat%   sum%        cum   cum%
   119.79s  5.59%  5.59%    119.79s  5.59%  .jbyte_disjoint_arraycopy
    71.06s  3.32%  8.91%    976.14s 45.55%  org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil.$anonfun$internalRowToText$1
    68.82s  3.21% 12.12%     69.28s  3.23%  java/lang/Long.getChars
    68.16s  3.18% 15.30%     69.58s  3.25%  scala/runtime/BoxesRunTime.boxToInteger
    66.02s  3.08% 18.38%     66.02s  3.08%  .[vdso]
    56.41s  2.63% 21.01%     68.10s  3.18%  java/lang/AbstractStringBuilder.ensureCapacityInternal
    53.82s  2.51% 23.52%     53.82s  2.51%  .itable stub
    45.14s  2.11% 25.63%     45.14s  2.11%  .jbyte_arraycopy
    44.45s  2.07% 27.70%    135.59s  6.33%  java/time/format/DateTimeFormatterBuilder$NumberPrinterParser.format
    44.25s  2.06% 29.77%    324.58s 15.15%  org/apache/spark/sql/catalyst/expressions/GeneratedClass$GeneratedIteratorForCodegenStage1.processNext
    43.76s  2.04% 31.81%     82.57s  3.85%  jdk/internal/math/FloatToDecimal.<init>
    41.56s  1.94% 33.75%   1015.03s 47.37%  org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil$$Lambda_.apply
    35.69s  1.67% 35.41%    244.94s 11.43%  java/lang/AbstractStringBuilder.append
    34.85s  1.63% 37.04%     34.85s  1.63%  .jlong_disjoint_arraycopy
    33.04s  1.54% 38.58%     38.21s  1.78%  java/time/OffsetDateTime.getLong
    32.05s  1.50% 40.08%    225.62s 10.53%  java/time/format/DateTimeFormatterBuilder$CompositePrinterParser.format
    31.33s  1.46% 41.54%   1054.44s 49.20%  scala/collection/IndexedSeqOptimized.foreach
    30.71s  1.43% 42.97%     30.71s  1.43%  libpthread-2.28.so.__write
    30.55s  1.43% 44.40%     87.44s  4.08%  jdk/internal/math/FloatToDecimal.toDecimal
    28.36s  1.32% 45.72%     28.36s  1.32%  libpthread-2.28.so..annobin___pthread_cond_timedwait.start
    25.46s  1.19% 46.91%       133s  6.21%  org/apache/orc/impl/TreeReaderFactory$FloatTreeReader.nextVector
    24.94s  1.16% 48.07%     24.95s  1.16%  java/lang/Long.stringSize
    24.10s  1.12% 49.20%     24.20s  1.13%  libjvm.so.void OopOopIterateDispatch<G1CMOopClosure>::Table::oop_oop_iterate<InstanceKlass, narrowOop>
    23.61s  1.10% 50.30%    252.51s 11.78%  scala/collection/mutable/StringBuilder.append
    22.20s  1.04% 51.34%     22.20s  1.04%  scala/collection/mutable/ArrayBuilder$ofRef.elems_$eq
    20.44s  0.95% 52.29%    101.11s  4.72%  java/lang/Long.toString
    19.39s   0.9% 53.19%     23.83s  1.11%  scala/runtime/BoxesRunTime.boxToBoolean
    19.15s  0.89% 54.09%        31s  1.45%  io/airlift/compress/snappy/SnappyRawDecompressor.uncompressAll
    18.95s  0.88% 54.97%     71.78s  3.35%  java/nio/HeapByteBuffer.get
    18.22s  0.85% 55.82%     23.34s  1.09%  java/time/format/DateTimeFormatterBuilder$CharLiteralPrinterParser.format
    17.90s  0.84% 56.66%    114.61s  5.35%  java/lang/String.getBytes
    17.24s   0.8% 57.46%     22.79s  1.06%  org/apache/spark/unsafe/bitset/BitSetMethods.isSet
    15.86s  0.74% 58.20%     19.53s  0.91%  org/apache/spark/sql/execution/datasources/orc/OrcColumnVector.isNullAt
    15.82s  0.74% 58.94%     53.05s  2.48%  jdk/internal/math/FloatToDecimal.toChars
    14.44s  0.67% 59.61%     21.32s  0.99%  scala/runtime/BoxesRunTime.boxToLong
    12.99s  0.61% 60.22%     12.99s  0.61%  sun/misc/Unsafe.putLong
    12.63s  0.59% 60.81%     12.75s  0.59%  java/lang/Integer.getChars
    11.33s  0.53% 61.34%     11.36s  0.53%  scala/collection/mutable/StringBuilder.underlying
     9.91s  0.46% 61.80%     57.98s  2.71%  org/apache/orc/impl/RunLengthIntegerReaderV2.nextVector
     9.25s  0.43% 62.23%     26.37s  1.23%  jdk/internal/math/FloatToDecimal.toChars1
     9.23s  0.43% 62.66%     99.47s  4.64%  org/apache/orc/impl/SerializationUtils.readFloat
     9.19s  0.43% 63.09%     63.61s  2.97%  libc-2.28.so.clock_gettime@@GLIBC_2.17
     9.06s  0.42% 63.52%     18.17s  0.85%  java/lang/String.<init>
     8.24s  0.38% 63.90%    116.07s  5.42%  scala/collection/IndexedSeqOptimized.zipWithIndex
     7.78s  0.36% 64.26%   1663.55s 77.63%  org/apache/spark/sql/execution/datasources/v2/WritingSparkTask.$anonfun$run$1
     7.29s  0.34% 64.60%     27.50s  1.28%  java/lang/Integer.toString
     7.16s  0.33% 64.94%     17.41s  0.81%  jdk/internal/math/FloatToDecimal.charsToString
     7.04s  0.33% 65.27%     18.53s  0.86%  libjvm.so.G1RebuildRSAndScrubTask::G1RebuildRSAndScrubRegionClosure::do_heap_region
     6.70s  0.31% 65.58%     11.82s  0.55%  java/lang/String.length
     5.57s  0.26% 65.84%     43.12s  2.01%  org/apache/orc/impl/InStream$CompressedStream.ensureUncompressed
     5.36s  0.25% 66.09%     48.07s  2.24%  org/apache/orc/impl/RunLengthIntegerReaderV2.next
     5.22s  0.24% 66.33%    116.76s  5.45%  java/lang/AbstractStringBuilder.putStringAt
     5.11s  0.24% 66.57%     27.64s  1.29%  org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.write
     4.89s  0.23% 66.80%     10.99s  0.51%  scala/reflect/ClassTag$.apply
     4.47s  0.21% 67.01%     26.92s  1.26%  com/itsumma/gpconnector/rmi/BufferExchange.put
     4.25s   0.2% 67.21%   1327.28s 61.94%  com/itsumma/gpconnector/writer/GreenplumDataWriter.write
     4.23s   0.2% 67.40%     31.72s  1.48%  org/apache/orc/impl/SerializationUtils.readLongBE
     4.06s  0.19% 67.59%   1333.31s 62.22%  com/itsumma/gpconnector/utils/ProgressTracker.trackProgress
     3.73s  0.17% 67.77%     10.89s  0.51%  scala/collection/mutable/StringBuilder.<init>
     3.60s  0.17% 67.93%        41s  1.91%  libjvm.so.void G1CMTask::process_grey_task_entry<true>
     3.44s  0.16% 68.10%     85.84s  4.01%  com/itsumma/gpconnector/rmi/RMISlave.write
        3s  0.14% 68.24%     41.55s  1.94%  com/itsumma/gpconnector/rmi/RMISlave.putLocal
     2.80s  0.13% 68.37%     13.67s  0.64%  java/time/ZoneId.of
     2.53s  0.12% 68.48%     48.10s  2.24%  libjvm.so.G1CMBitMapClosure::do_addr
     2.41s  0.11% 68.60%    117.09s  5.46%  org/apache/orc/impl/InStream$CompressedStream.read
     2.16s   0.1% 68.70%     56.79s  2.65%  java/time/format/DateTimePrintContext.getValue
     2.04s 0.095% 68.79%     21.16s  0.99%  libjvm.so.G1CMTask::drain_local_queue
     1.82s 0.085% 68.88%   1198.12s 55.91%  org/apache/spark/sql/itsumma/gpconnector/SparkSchemaUtil.internalRowToText
     1.77s 0.083% 68.96%    190.26s  8.88%  jdk/internal/math/FloatToDecimal.toString
     1.67s 0.078% 69.04%     18.97s  0.89%  java/time/LocalDateTime.ofEpochSecond
     1.59s 0.074% 69.11%     25.74s  1.20%  libjvm.so.HeapRegionManager::par_iterate
     1.53s 0.071% 69.18%     35.30s  1.65%  org/apache/orc/impl/RunLengthIntegerReaderV2.readDirectValues
     1.51s  0.07% 69.25%    231.23s 10.79%  java/time/format/DateTimeFormatter.formatTo
     1.39s 0.065% 69.32%     13.87s  0.65%  libjvm.so.Unsafe_Park
     1.34s 0.063% 69.38%     10.72s   0.5%  org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.writeLong
     1.27s 0.059% 69.44%    105.85s  4.94%  jdk/internal/math/FloatToDecimal.toDecimalString
     1.19s 0.056% 69.50%     57.56s  2.69%  libjvm.so.G1CMTask::do_marking_step
     1.18s 0.055% 69.55%     26.90s  1.26%  java/time/ZonedDateTime.ofInstant
     1.13s 0.053% 69.60%     34.83s  1.63%  org/apache/orc/impl/SerializationUtils.unrolledUnPackBytes
     1.11s 0.052% 69.66%     42.67s  1.99%  org/apache/orc/impl/RunLengthIntegerReaderV2.readValues
     1.01s 0.047% 69.70%    246.13s 11.49%  java/lang/StringBuilder.append
     1.01s 0.047% 69.75%     44.86s  2.09%  jdk/internal/misc/Unsafe.park
     0.98s 0.046% 69.80%     23.77s  1.11%  org/apache/spark/sql/catalyst/expressions/UnsafeRow.isNullAt
     0.68s 0.032% 69.83%    326.03s 15.21%  org/apache/spark/sql/execution/WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext
     0.64s  0.03% 69.86%     25.33s  1.18%  java/time/ZonedDateTime.create
     0.63s 0.029% 69.89%     61.02s  2.85%  com/itsumma/gpconnector/rmi/RMISlave.tryGet
     0.59s 0.028% 69.91%     12.73s  0.59%  org/apache/spark/internal/Logging.logTrace
     0.53s 0.025% 69.94%   1199.19s 55.96%  com/itsumma/gpconnector/writer/GreenplumDataWriter$$Lambda_.apply
     0.48s 0.022% 69.96%   1327.76s 61.96%  org/apache/spark/sql/execution/datasources/v2/DataWritingSparkTask$.write
     0.45s 0.021% 69.98%     36.23s  1.69%  org/apache/orc/impl/SerializationUtils.readInts
     0.44s 0.021% 70.00%     27.16s  1.27%  java/time/Instant.atZone
     0.43s  0.02% 70.02%    325.32s 15.18%  org/apache/spark/sql/execution/BufferedRowIterator.hasNext
     0.29s 0.014% 70.04%    142.43s  6.65%  libjvm.so..annobin__ZN12WorkerThread3runEv.start
     0.29s 0.014% 70.05%     31.24s  1.46%  sun/nio/ch/SocketDispatcher.write0
     0.28s 0.013% 70.06%     58.18s  2.71%  com/itsumma/gpconnector/rmi/BufferExchange.get
     0.28s 0.013% 70.08%     23.61s  1.10%  scala/collection/MapLike.getOrElse
     0.26s 0.012% 70.09%     51.18s  2.39%  java/util/concurrent/locks/AbstractQueuedSynchronizer$ConditionObject.awaitNanos
     0.24s 0.011% 70.10%     13.97s  0.65%  libjvm.so.MemAllocator::allocate
     0.21s 0.0098% 70.11%     34.87s  1.63%  sun/net/httpserver/Request$WriteStream.write
     0.20s 0.0093% 70.12%     61.59s  2.87%  com/itsumma/gpconnector/rmi/RMISlave.read
     0.20s 0.0093% 70.13%    116.06s  5.42%  scala/collection/IndexedSeqOptimized.zipWithIndex$
     0.17s 0.0079% 70.14%   1198.66s 55.93%  com/itsumma/gpconnector/writer/GreenplumDataWriter.$anonfun$write$1
     0.17s 0.0079% 70.14%     49.77s  2.32%  org/apache/orc/impl/TreeReaderFactory$LongTreeReader.nextVector
     0.14s 0.0065% 70.15%     36.45s  1.70%  sun/net/httpserver/ChunkedOutputStream.writeChunk
     0.13s 0.0061% 70.16%    102.09s  4.76%  com/itsumma/gpconnector/gpfdist/WebServer$$anon$1.handle
     0.13s 0.0061% 70.16%     31.14s  1.45%  io/airlift/compress/snappy/SnappyRawDecompressor.decompress
     0.10s 0.0047% 70.17%   1795.25s 83.77%  java/lang/Thread.run
     0.10s 0.0047% 70.17%     33.75s  1.57%  sun/nio/ch/SocketChannelImpl.write
     0.08s 0.0037% 70.18%     32.72s  1.53%  libjvm.so.G1EvacuateRegionsBaseTask::work
     0.08s 0.0037% 70.18%     11.66s  0.54%  scala/collection/mutable/FlatHashTable.findElemImpl
     0.07s 0.0033% 70.18%     99.59s  4.65%  com/itsumma/gpconnector/gpfdist/WebServer$$anon$1$$Lambda_.apply$mcV$sp
     0.06s 0.0028% 70.19%     13.14s  0.61%  jdk/internal/loader/BuiltinClassLoader.loadClassOrNull
     0.06s 0.0028% 70.19%     25.88s  1.21%  libjvm.so.PhaseChaitin::Register_Allocate
     0.06s 0.0028% 70.19%    194.78s  9.09%  org/apache/orc/impl/reader/tree/StructBatchReader.nextBatchForLevel
     0.06s 0.0028% 70.19%     38.50s  1.80%  sun/net/httpserver/ChunkedOutputStream.write
     0.05s 0.0023% 70.20%     31.53s  1.47%  org/apache/orc/impl/InStream$CompressedStream.readHeader
     0.05s 0.0023% 70.20%     23.66s  1.10%  scala/collection/MapLike.getOrElse$
     0.05s 0.0023% 70.20%    100.86s  4.71%  scala/runtime/java8/JFunction0$mcV$sp.apply
     0.05s 0.0023% 70.20%     32.24s  1.50%  sun/nio/ch/IOUtil.write
     0.04s 0.0019% 70.20%     18.30s  0.85%  libjvm.so.G1ParEvacuateFollowersClosure::do_void
     0.04s 0.0019% 70.21%    205.94s  9.61%  org/apache/spark/sql/catalyst/expressions/GeneratedClass$GeneratedIteratorForCodegenStage1.columnartorow_nextBatch_0$
     0.04s 0.0019% 70.21%     20.57s  0.96%  scala/collection/Iterator$$anon$11.hasNext
     0.04s 0.0019% 70.21%     30.56s  1.43%  sun/nio/ch/IOUtil.writeFromNativeBuffer
     0.03s 0.0014% 70.21%     10.91s  0.51%  jdk/internal/loader/BuiltinClassLoader.defineClass
     0.03s 0.0014% 70.21%     13.95s  0.65%  libjvm.so.Compilation::Compilation
     0.03s 0.0014% 70.21%     86.46s  4.03%  libjvm.so.CompileBroker::invoke_compiler_on_method
     0.03s 0.0014% 70.22%     90.24s  4.21%  org/apache/orc/impl/SerializationUtils.readFully
     0.03s 0.0014% 70.22%    194.81s  9.09%  org/apache/orc/impl/reader/tree/StructBatchReader.nextBatch
     0.02s 0.00093% 70.22%    236.96s 11.06%  java/time/format/DateTimeFormatter.format
     0.02s 0.00093% 70.22%     24.77s  1.16%  libjvm.so.Compile::Optimize
     0.02s 0.00093% 70.22%    198.43s  9.26%  org/apache/orc/impl/RecordReaderImpl.nextBatch
     0.02s 0.00093% 70.22%     12.75s  0.59%  org/apache/spark/internal/Logging.logTrace$
     0.02s 0.00093% 70.22%    198.45s  9.26%  org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.nextBatch
     0.01s 0.00047% 70.22%     38.51s  1.80%  com/itsumma/gpconnector/gpfdist/WebServer$$anon$1.$anonfun$handle$4
     0.01s 0.00047% 70.22%     60.70s  2.83%  com/itsumma/gpconnector/gpfdist/WebServer$$anon$1.$anonfun$handle$5
     0.01s 0.00047% 70.22%     13.17s  0.61%  java/lang/ClassLoader.loadClass
     0.01s 0.00047% 70.22%   1795.15s 83.77%  java/lang/Thread.runWith
     0.01s 0.00047% 70.22%     44.60s  2.08%  java/util/concurrent/locks/LockSupport.parkNanos
     0.01s 0.00047% 70.22%     12.43s  0.58%  jdk/internal/loader/BuiltinClassLoader.findClassOnClassPathOrNull
     0.01s 0.00047% 70.23%     13.92s  0.65%  libjvm.so..annobin__ZN11Compilation14compile_methodEv.start
     0.01s 0.00047% 70.23%     12.37s  0.58%  libjvm.so.Compilation::compile_java_method
     0.01s 0.00047% 70.23%     71.54s  3.34%  libjvm.so.Compile::Compile
     0.01s 0.00047% 70.23%     87.13s  4.07%  libjvm.so.CompileBroker::compiler_thread_loop
     0.01s 0.00047% 70.23%     60.01s  2.80%  libjvm.so.G1CMConcurrentMarkingTask::work
     0.01s 0.00047% 70.23%     13.93s  0.65%  libjvm.so.PhaseIdealLoop::build_and_optimize
     0.01s 0.00047% 70.23%    238.12s 11.11%  libjvm.so.thread_native_entry
     0.01s 0.00047% 70.23%    194.54s  9.08%  org/apache/orc/impl/reader/tree/StructBatchReader.readBatchColumn
     0.01s 0.00047% 70.23%   1664.38s 77.67%  org/apache/spark/executor/Executor$TaskRunner.run
     0.01s 0.00047% 70.23%    203.86s  9.51%  org/apache/spark/sql/execution/FileSourceScanExec$$anon$1.hasNext
     0.01s 0.00047% 70.23%    203.82s  9.51%  org/apache/spark/sql/execution/datasources/FileScanRDD$$anon$1.hasNext
     0.01s 0.00047% 70.23%     21.37s     1%  py4j/ClientServerConnection.waitForCommands
     0.01s 0.00047% 70.23%    103.12s  4.81%  sun/net/httpserver/ServerImpl$Exchange.run
         0     0% 70.23%     67.75s  3.16%  .not_walkable_Java
         0     0% 70.23%     68.03s  3.17%  .unknown
         0     0% 70.23%     16.59s  0.77%  .unknown_Java
         0     0% 70.23%    102.09s  4.76%  com/sun/net/httpserver/Filter$Chain.doFilter
         0     0% 70.23%     31.14s  1.45%  io/airlift/compress/snappy/SnappyDecompressor.decompress
         0     0% 70.23%    190.26s  8.88%  java/lang/Float.toString
         0     0% 70.23%     15.71s  0.73%  java/lang/reflect/Method.invoke
         0     0% 70.23%   1770.57s 82.62%  java/util/concurrent/ThreadPoolExecutor$Worker.run
         0     0% 70.23%   1770.57s 82.62%  java/util/concurrent/ThreadPoolExecutor.runWorker
         0     0% 70.23%     13.15s  0.61%  jdk/internal/loader/BuiltinClassLoader.loadClass
         0     0% 70.23%     12.99s  0.61%  jdk/internal/loader/ClassLoaders$AppClassLoader.loadClass
         0     0% 70.23%     15.69s  0.73%  jdk/internal/reflect/DelegatingMethodAccessorImpl.invoke
         0     0% 70.23%     14.53s  0.68%  jdk/internal/reflect/NativeMethodAccessorImpl.invoke
         0     0% 70.23%     14.50s  0.68%  jdk/internal/reflect/NativeMethodAccessorImpl.invoke0
         0     0% 70.23%     16.37s  0.76%  libjvm.so..annobin__ZN14PhaseIdealLoop8optimizeER12PhaseIterGVN12LoopOptsMode.start
         0     0% 70.23%     13.65s  0.64%  libjvm.so..annobin__ZN21G1EvacuateRegionsTask10scan_rootsEP20G1ParScanThreadStatej.start
         0     0% 70.23%     17.58s  0.82%  libjvm.so..annobin__ZN21G1EvacuateRegionsTask21evacuate_live_objectsEP20G1ParScanThreadStatej.start
         0     0% 70.23%     21.61s  1.01%  libjvm.so..annobin__ZN23G1RebuildRSAndScrubTask4workEj.start
         0     0% 70.23%     71.55s  3.34%  libjvm.so.C2Compiler::compile_method
         0     0% 70.23%     39.46s  1.84%  libjvm.so.Compile::Code_Gen
         0     0% 70.23%     13.96s  0.65%  libjvm.so.Compiler::compile_method
         0     0% 70.23%     87.75s  4.09%  libjvm.so.JavaThread::thread_main_inner
         0     0% 70.23%    238.09s 11.11%  libjvm.so.Thread::call_run
         0     0% 70.23%    238.14s 11.11%  libpthread-2.28.so.start_thread
         0     0% 70.23%     31.14s  1.45%  org/apache/orc/impl/AircompressorCodec.decompress
         0     0% 70.23%     16.30s  0.76%  org/apache/orc/impl/SerializationUtils.unrolledUnPack32
         0     0% 70.23%     12.23s  0.57%  org/apache/orc/impl/SerializationUtils.unrolledUnPack40
         0     0% 70.23%     31.14s  1.45%  org/apache/orc/impl/SnappyCodec.decompress
         0     0% 70.23%   1664.01s 77.65%  org/apache/spark/TaskContext.runTaskWithListeners
         0     0% 70.23%   1664.07s 77.65%  org/apache/spark/executor/Executor$TaskRunner$$Lambda_.apply
         0     0% 70.23%   1664.07s 77.65%  org/apache/spark/executor/Executor$TaskRunner.$anonfun$run$4
         0     0% 70.23%      1664s 77.65%  org/apache/spark/scheduler/ResultTask.runTask
         0     0% 70.23%   1664.07s 77.65%  org/apache/spark/scheduler/Task.run
         0     0% 70.23%    198.47s  9.26%  org/apache/spark/sql/execution/datasources/RecordReaderIterator.hasNext
         0     0% 70.23%    198.45s  9.26%  org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.nextKeyValue
         0     0% 70.23%   1663.64s 77.63%  org/apache/spark/sql/execution/datasources/v2/DataWritingSparkTask$.run
         0     0% 70.23%   1663.64s 77.63%  org/apache/spark/sql/execution/datasources/v2/V2TableWriteExec$$Lambda_.apply
         0     0% 70.23%   1663.64s 77.63%  org/apache/spark/sql/execution/datasources/v2/V2TableWriteExec.$anonfun$writeWithV2$2
         0     0% 70.23%   1663.55s 77.63%  org/apache/spark/sql/execution/datasources/v2/WritingSparkTask$$Lambda_.apply
         0     0% 70.23%   1663.64s 77.63%  org/apache/spark/sql/execution/datasources/v2/WritingSparkTask.run
         0     0% 70.23%   1663.64s 77.63%  org/apache/spark/sql/execution/datasources/v2/WritingSparkTask.run$
         0     0% 70.23%   1664.18s 77.66%  org/apache/spark/util/SparkErrorUtils.tryWithSafeFinally
         0     0% 70.23%   1664.18s 77.66%  org/apache/spark/util/SparkErrorUtils.tryWithSafeFinally$
         0     0% 70.23%   1664.18s 77.66%  org/apache/spark/util/Utils$.tryWithSafeFinally
         0     0% 70.23%   1663.55s 77.63%  org/apache/spark/util/Utils$.tryWithSafeFinallyAndFailureCallbacks
         0     0% 70.23%     21.37s     1%  py4j/ClientServerConnection.run
         0     0% 70.23%     20.52s  0.96%  py4j/Gateway.invoke
         0     0% 70.23%     13.59s  0.63%  py4j/commands/AbstractCommand.invokeMethod
         0     0% 70.23%     13.70s  0.64%  py4j/commands/CallCommand.execute
         0     0% 70.23%     20.22s  0.94%  py4j/reflection/MethodInvoker.invoke
         0     0% 70.23%     20.22s  0.94%  py4j/reflection/ReflectionEngine.invoke
         0     0% 70.23%     23.82s  1.11%  scala/Predef$.boolean2Boolean
         0     0% 70.23%     23.66s  1.10%  scala/collection/AbstractMap.getOrElse
         0     0% 70.23%   1054.45s 49.20%  scala/collection/IndexedSeqOptimized.foreach$
         0     0% 70.23%     23.94s  1.12%  scala/collection/mutable/ArrayBuilder$ofRef.resize
         0     0% 70.23%     23.89s  1.11%  scala/collection/mutable/ArrayBuilder$ofRef.sizeHint
         0     0% 70.23%   1053.81s 49.17%  scala/collection/mutable/ArrayOps$ofRef.foreach
         0     0% 70.23%    116.06s  5.42%  scala/collection/mutable/ArrayOps$ofRef.zipWithIndex
         0     0% 70.23%     11.66s  0.54%  scala/collection/mutable/FlatHashTable.containsElem
         0     0% 70.23%     11.66s  0.54%  scala/collection/mutable/FlatHashTable.containsElem$
         0     0% 70.23%     11.66s  0.54%  scala/collection/mutable/HashSet.contains
         0     0% 70.23%     11.66s  0.54%  scala/collection/mutable/HashSet.containsElem
         0     0% 70.23%     21.98s  1.03%  scala/runtime/java8/JFunction0$mcJ$sp.apply
         0     0% 70.23%    102.09s  4.76%  sun/net/httpserver/AuthFilter.doFilter
         0     0% 70.23%     38.50s  1.80%  sun/net/httpserver/PlaceholderOutputStream.write
         0     0% 70.23%    102.09s  4.76%  sun/net/httpserver/ServerImpl$Exchange$LinkHandler.handle
         0     0% 70.23%     31.24s  1.46%  sun/nio/ch/SocketDispatcher.write
```
</details>
